### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,10 +404,10 @@ Note that even if this works, before A becomes `ready`, B “consumes” a `star
 If we are unlucky, things can happen in this order:
 
 * B and C are started. They are waiting for being able to connect to A
-* A is not started because we already have two processes in the starting mode.
+* A is not started because we already have two processes in the starting mode which is the maximum allowed by our policy.
 * We’re dead-locked.
 
-![Unluck flow](https://rawgithub.com/lhuard1A/throttling-study/master/unlucky_flow.svg)
+![Unlucky flow](https://rawgithub.com/lhuard1A/throttling-study/master/unlucky_flow.svg)
 
 This trivial example shows that
 * limiting the number of processes starting at a time and


### PR DESCRIPTION
Regarding this point:
- When there are containers in the `pending` state, the throttling mechanism regularly checks if conditions are met to take a `pending` container and make it progress to `starting`.
  
  We should define "regularly" , I think that sticking to minRate value would be sufficient, hence the requirement to set minRate to mandatory. And putting it to an integer, so minimum is 1 per second would also help to simplify implementation
